### PR TITLE
Print a status message on failure

### DIFF
--- a/chromium_x_refs.py
+++ b/chromium_x_refs.py
@@ -474,12 +474,16 @@ class ChromiumXrefsCommand(sublime_plugin.TextCommand):
     self.show_tests = True;
 
     if not self.getSignatureForSelection(edit):
-      print("Could not find signature for: " + self.selected_word);
+      msg = "Could not find signature for: " + self.selected_word;
+      self.view.window().status_message(msg);
+      print(msg);
       return;
 
     self.xrefs = getXrefsFor(self.file_path, self.signature);
     if not self.xrefs:
-      print("Could not find xrefs for: " + self.selected_word);
+      msg = "Could not find xrefs for: " + self.selected_word;
+      self.view.window().status_message(msg);
+      print(msg);
       return;
 
     self.callers = getCallGraphFor(self.file_path, self.signature);


### PR DESCRIPTION
This is useful when e.g., you're working on Android code which isn't indexed, and half the things you try to look up are not found. It just displays the message in the bottom left.